### PR TITLE
fix(data): add server timestamps estimation to document data retrieval

### DIFF
--- a/src/data/participant/mapper.ts
+++ b/src/data/participant/mapper.ts
@@ -5,7 +5,9 @@ import { type DocumentData, type DocumentSnapshot } from 'firebase/firestore';
 import { type ParticipantDoc } from './types';
 
 function toParticipant(doc: DocumentSnapshot<ParticipantDoc, DocumentData>): Participant {
-  const data = doc.data();
+  const data = doc.data({
+    serverTimestamps: 'estimate',
+  });
 
   if (!data) {
     throw new Error('Participant not found');

--- a/src/data/round/mapper.ts
+++ b/src/data/round/mapper.ts
@@ -6,7 +6,9 @@ import { assertValid } from '@/shared/zod/utils';
 import { type RoundDoc } from './types';
 
 function toRound(doc: DocumentSnapshot<RoundDoc, DocumentData>): Round {
-  const data = doc.data();
+  const data = doc.data({
+    serverTimestamps: 'estimate',
+  });
 
   if (!data) {
     throw new Error('Round not found');

--- a/src/data/session/mapper.ts
+++ b/src/data/session/mapper.ts
@@ -6,7 +6,9 @@ import { type Session } from '@/domain/session/types';
 import { assertValid } from '@/shared/zod/utils';
 
 function toSession(doc: DocumentSnapshot<SessionDoc, DocumentData>): Session {
-  const data = doc.data();
+  const data = doc.data({
+    serverTimestamps: 'estimate',
+  });
 
   if (!data) {
     throw new Error('Session not found');

--- a/src/data/session/stream-session.ts
+++ b/src/data/session/stream-session.ts
@@ -12,7 +12,9 @@ export function streamSession(
     doc(sessionsCollection, sessionId),
     (doc) => {
       if (doc.exists()) {
-        const data = doc.data();
+        const data = doc.data({
+          serverTimestamps: 'estimate',
+        });
         callback({
           id: doc.id,
           name: data.name,

--- a/src/data/vote/mapper.ts
+++ b/src/data/vote/mapper.ts
@@ -5,7 +5,9 @@ import { type DocumentData, type DocumentSnapshot } from 'firebase/firestore';
 import { type VoteDoc } from './types';
 
 function toVote(doc: DocumentSnapshot<VoteDoc, DocumentData>): Vote {
-  const data = doc.data();
+  const data = doc.data({
+    serverTimestamps: 'estimate',
+  });
 
   if (!data) {
     throw new Error('Vote not found');


### PR DESCRIPTION
This pull request is fixing problem on issue #92 

### Issue
When mapping participant data from Firestore to our domain model, the `updatedAt` field was occasionally returning as `null`. This occurred because our mapper was attempting to access the timestamp before Firestore had fully resolved the server timestamp value, even though the field was properly recorded in the database.

### Solution
Added the `serverTimestamps: "estimate"` option to the `doc.data()` call in the participant mapper. This instructs Firestore to provide an estimated timestamp value when reading server timestamps that haven't been fully resolved yet in the local cache.

### Technical Details
The issue was related to Firestore's handling of server timestamps in the client SDK. When reading a document that contains server timestamps, there's a period where the local cache has a sentinel value instead of the actual timestamp. Without specifying how to handle these sentinel values, they appear as null when accessed.

By using the `"estimate"` option, we ensure our application has immediate access to a reasonable timestamp value without waiting for the server to fully resolve the actual timestamp. This prevents null values from breaking our application logic.

https://jam.dev/c/78213926-eaab-4049-bea1-65ee0bc17e86

[5b211759-aba4-43c3-9867-b01975c11aa2.webm](https://github.com/user-attachments/assets/8e5221e0-e200-41ba-b479-1ef58ec6a013)