### PR TITLE
fix: prevent app freeze when returning from background

### DIFF
--- a/src/hooks/participant/use-stream-participants.ts
+++ b/src/hooks/participant/use-stream-participants.ts
@@ -1,21 +1,38 @@
 import { streamParticipants } from '@/data/participant/stream-participants';
 import { type Participant } from '@/domain/participant/types';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { usePageVisibility } from '@/hooks/use-page-visibility';
 
 export function useStreamParticipants(sessionId: string) {
   const [participants, setParticipants] = useState<Participant[]>([]);
+  const isVisible = usePageVisibility();
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+
   useEffect(() => {
-    if (!sessionId) {
-      return;
+    if (!sessionId) return;
+
+    const startListening = () => {
+      unsubscribeRef.current = streamParticipants(sessionId, setParticipants);
+    };
+
+    const stopListening = () => {
+      if (unsubscribeRef.current) {
+        unsubscribeRef.current();
+        unsubscribeRef.current = null;
+      }
+    };
+
+    if (isVisible) {
+      startListening();
+    } else {
+      stopListening();
     }
 
-    const unsubscribe = streamParticipants(sessionId, setParticipants);
-
     return () => {
-      unsubscribe();
+      stopListening();
     };
-  }, [sessionId]);
+  }, [sessionId, isVisible]);
 
   return { participants };
 }

--- a/src/hooks/round/use-stream-active-round.ts
+++ b/src/hooks/round/use-stream-active-round.ts
@@ -1,14 +1,37 @@
 import { streamActiveRound } from '@/data/round/stream-active-round';
 import { type Round } from '@/domain/round/types';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { usePageVisibility } from '@/hooks/use-page-visibility';
 
 export function useStreamActiveRound(sessionId: string) {
   const [activeRound, setActiveRound] = useState<Round | undefined>(undefined);
+  const isVisible = usePageVisibility();
+  const unsubscribeRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
-    const unsubscribe = streamActiveRound(sessionId, setActiveRound);
-    return () => unsubscribe();
-  }, [sessionId]);
+    if (!sessionId) return;
+
+    const startListening = () => {
+      unsubscribeRef.current = streamActiveRound(sessionId, setActiveRound);
+    };
+
+    const stopListening = () => {
+      if (unsubscribeRef.current) {
+        unsubscribeRef.current();
+        unsubscribeRef.current = null;
+      }
+    };
+
+    if (isVisible) {
+      startListening();
+    } else {
+      stopListening();
+    }
+
+    return () => {
+      stopListening();
+    };
+  }, [sessionId, isVisible]);
 
   return { round: activeRound };
 }

--- a/src/hooks/session/use-stream-session.ts
+++ b/src/hooks/session/use-stream-session.ts
@@ -1,27 +1,70 @@
 import { streamSession } from '@/data/session/stream-session';
 import { type Session } from '@/domain/session/types';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { useConnectionState } from '@/hooks/use-connection-state';
 
 export function useStreamSession(sessionId: string) {
   const [session, setSession] = useState<Session | undefined>();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | undefined>();
+  const { isConnected, isReconnecting } = useConnectionState();
+  const unsubscribeRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
-    setLoading(true);
-    const unsubscribe = streamSession(
-      sessionId,
-      (data) => {
-        setSession(data);
-        setLoading(false);
-      },
-      (error) => {
-        setError(error);
-        setLoading(false);
-      },
-    );
-    return () => unsubscribe();
-  }, [sessionId]);
+    if (!sessionId) return;
+
+    const startListening = () => {
+      if (isReconnecting) {
+        // Add slight delay for reconnecting state to prevent race conditions
+        setTimeout(() => {
+          setLoading(true);
+          unsubscribeRef.current = streamSession(
+            sessionId,
+            (data) => {
+              setSession(data);
+              setLoading(false);
+              setError(undefined);
+            },
+            (error) => {
+              setError(error);
+              setLoading(false);
+            },
+          );
+        }, 50);
+      } else {
+        setLoading(true);
+        unsubscribeRef.current = streamSession(
+          sessionId,
+          (data) => {
+            setSession(data);
+            setLoading(false);
+            setError(undefined);
+          },
+          (error) => {
+            setError(error);
+            setLoading(false);
+          },
+        );
+      }
+    };
+
+    const stopListening = () => {
+      if (unsubscribeRef.current) {
+        unsubscribeRef.current();
+        unsubscribeRef.current = null;
+      }
+    };
+
+    if (isConnected || isReconnecting) {
+      startListening();
+    } else {
+      stopListening();
+    }
+
+    return () => {
+      stopListening();
+    };
+  }, [sessionId, isConnected, isReconnecting]);
 
   return { session, loading, error };
 }

--- a/src/hooks/use-connection-state.ts
+++ b/src/hooks/use-connection-state.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { usePageVisibility } from './use-page-visibility';
+
+type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'reconnecting';
+
+export function useConnectionState() {
+  const [connectionState, setConnectionState] = useState<ConnectionState>('connecting');
+  const isVisible = usePageVisibility();
+
+  useEffect(() => {
+    if (!isVisible) {
+      setConnectionState('disconnected');
+      return;
+    }
+
+    if (connectionState === 'disconnected') {
+      setConnectionState('reconnecting');
+      // Add a small delay to prevent simultaneous reconnection attempts
+      const timer = setTimeout(() => {
+        setConnectionState('connected');
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+
+    if (connectionState === 'connecting') {
+      setConnectionState('connected');
+    }
+  }, [isVisible, connectionState]);
+
+  const isConnected = connectionState === 'connected';
+  const isReconnecting = connectionState === 'reconnecting';
+
+  return {
+    connectionState,
+    isConnected,
+    isReconnecting,
+    setConnectionState,
+  };
+}

--- a/src/hooks/use-page-visibility.ts
+++ b/src/hooks/use-page-visibility.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export function usePageVisibility() {
+  const [isVisible, setIsVisible] = useState(!document.hidden);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setIsVisible(!document.hidden);
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  return isVisible;
+}

--- a/src/hooks/vote/use-stream-votes.ts
+++ b/src/hooks/vote/use-stream-votes.ts
@@ -1,21 +1,37 @@
 import { streamVotes } from '@/data/vote/stream-votes';
 import { type Vote } from '@/domain/vote/types';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { usePageVisibility } from '@/hooks/use-page-visibility';
 
 export function useStreamVotes(roundId: string) {
   const [votes, setVotes] = useState<Vote[]>([]);
+  const isVisible = usePageVisibility();
+  const unsubscribeRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
-    if (!roundId) {
-      return;
+    if (!roundId) return;
+
+    const startListening = () => {
+      unsubscribeRef.current = streamVotes(roundId, setVotes);
+    };
+
+    const stopListening = () => {
+      if (unsubscribeRef.current) {
+        unsubscribeRef.current();
+        unsubscribeRef.current = null;
+      }
+    };
+
+    if (isVisible) {
+      startListening();
+    } else {
+      stopListening();
     }
 
-    const unsubscribe = streamVotes(roundId, setVotes);
-
     return () => {
-      unsubscribe();
+      stopListening();
     };
-  }, [roundId]);
+  }, [roundId, isVisible]);
 
   return { votes };
 }


### PR DESCRIPTION
- Add Page Visibility API hook to detect background/foreground state
- Update all Firestore streaming hooks to pause/resume listeners based on visibility
- Add connection state management to prevent race conditions during reconnection
- Implement staggered reconnection timing to avoid simultaneous listener conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)