### PR TITLE
feat: implement win streak feature with fire badges

### DIFF
--- a/src/components/__tests__/win-streak-badge.test.tsx
+++ b/src/components/__tests__/win-streak-badge.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { WinStreakBadge } from '../win-streak-badge';
+
+describe('WinStreakBadge', () => {
+  it('should not render when streak is 0', () => {
+    const { container } = render(<WinStreakBadge streak={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render fire icon and streak count when streak > 0', () => {
+    render(<WinStreakBadge streak={3} />);
+    
+    expect(screen.getByText('🔥')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('should apply custom className', () => {
+    const { container } = render(<WinStreakBadge streak={1} className="custom-class" />);
+    
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('should display correct streak number', () => {
+    render(<WinStreakBadge streak={10} />);
+    
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+});

--- a/src/components/original-estimate-dialog.tsx
+++ b/src/components/original-estimate-dialog.tsx
@@ -1,0 +1,103 @@
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useState } from 'react';
+
+interface OriginalEstimateDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (estimate: number) => void;
+  cards: Array<{ value: number; displayValue: string }>;
+}
+
+/**
+ * Dialog component for game owner to input original estimate before revealing votes
+ */
+export function OriginalEstimateDialog({
+  isOpen,
+  onClose,
+  onSubmit,
+  cards,
+}: OriginalEstimateDialogProps) {
+  const [selectedEstimate, setSelectedEstimate] = useState<number | null>(null);
+  const [customEstimate, setCustomEstimate] = useState('');
+
+  const handleSubmit = () => {
+    const estimate = selectedEstimate ?? Number(customEstimate);
+    if (!isNaN(estimate) && estimate >= 0) {
+      onSubmit(estimate);
+      onClose();
+      setSelectedEstimate(null);
+      setCustomEstimate('');
+    }
+  };
+
+  const handleCardSelect = (value: number) => {
+    setSelectedEstimate(value);
+    setCustomEstimate('');
+  };
+
+  const handleCustomChange = (value: string) => {
+    setCustomEstimate(value);
+    setSelectedEstimate(null);
+  };
+
+  const isValid = selectedEstimate !== null || (!isNaN(Number(customEstimate)) && customEstimate !== '');
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className='sm:max-w-[425px]'>
+        <DialogHeader>
+          <DialogTitle>Set Original Estimate</DialogTitle>
+          <DialogDescription>
+            Enter the original estimate for this story to track win streaks. Participants who voted for this value will get a winning streak.
+          </DialogDescription>
+        </DialogHeader>
+        <div className='grid gap-4 py-4'>
+          <div className='space-y-2'>
+            <Label>Select from cards:</Label>
+            <div className='grid grid-cols-4 gap-2'>
+              {cards.map((card) => (
+                <Button
+                  key={card.value}
+                  variant={selectedEstimate === card.value ? 'default' : 'outline'}
+                  size='sm'
+                  onClick={() => handleCardSelect(card.value)}
+                >
+                  {card.displayValue}
+                </Button>
+              ))}
+            </div>
+          </div>
+          <div className='space-y-2'>
+            <Label htmlFor='custom-estimate'>Or enter custom value:</Label>
+            <Input
+              id='custom-estimate'
+              type='number'
+              placeholder='Enter estimate'
+              value={customEstimate}
+              onChange={(e) => handleCustomChange(e.target.value)}
+              min='0'
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant='outline' onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!isValid}>
+            Reveal Votes
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/win-streak-badge.tsx
+++ b/src/components/win-streak-badge.tsx
@@ -1,0 +1,27 @@
+import { cn } from '@/lib/cn';
+
+interface WinStreakBadgeProps {
+  streak: number;
+  className?: string;
+}
+
+/**
+ * Component to display win streak with fire icon
+ */
+export function WinStreakBadge({ streak, className }: WinStreakBadgeProps) {
+  if (streak === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-1 rounded-full bg-orange-500 px-2 py-1 text-xs font-bold text-white shadow-md',
+        className,
+      )}
+    >
+      <span>🔥</span>
+      <span>{streak}</span>
+    </div>
+  );
+}

--- a/src/containers/game-actions.tsx
+++ b/src/containers/game-actions.tsx
@@ -1,4 +1,6 @@
+import { OriginalEstimateDialog } from '@/components/original-estimate-dialog';
 import { Button } from '@/components/ui/button';
+import { useRevealRoundWithStreaks } from '@/hooks/round/use-reveal-round-with-streaks';
 import { useGame } from '@/providers/game';
 import { useParticipant } from '@/providers/participant';
 import { copyJoinLink } from '@/shared/utils/copy-join-link';
@@ -8,18 +10,34 @@ import SessionLeaveButton from './session-leave-button';
 
 export default function GameActions() {
   const { participant } = useParticipant();
-  const { round, revealRound, revoteRound, startNewRound, participants } = useGame();
+  const { round, revealRound, revoteRound, startNewRound, participants, cards } = useGame();
   const [isCooldown, setIsCooldown] = useState(false);
+  const [isEstimateDialogOpen, setIsEstimateDialogOpen] = useState(false);
+  
+  const revealRoundWithStreaksMutation = useRevealRoundWithStreaks();
 
   const handleRevealRound = () => {
-    revealRound();
-    setIsCooldown(true);
+    setIsEstimateDialogOpen(true);
+  };
 
-    const timer = setTimeout(() => {
-      setIsCooldown(false);
-    }, 2000);
+  const handleRevealWithEstimate = async (originalEstimate: number) => {
+    if (!round) return;
+    
+    try {
+      await revealRoundWithStreaksMutation.mutateAsync({
+        roundId: round.id,
+        originalEstimate,
+      });
+      setIsCooldown(true);
+      
+      const timer = setTimeout(() => {
+        setIsCooldown(false);
+      }, 2000);
 
-    return () => clearTimeout(timer);
+      return () => clearTimeout(timer);
+    } catch (error) {
+      toast.error('Failed to reveal round');
+    }
   };
 
   const handleCopyJoinLink = () => {
@@ -71,6 +89,12 @@ export default function GameActions() {
             </Button>
           </>
         )}
+        <OriginalEstimateDialog
+          isOpen={isEstimateDialogOpen}
+          onClose={() => setIsEstimateDialogOpen(false)}
+          onSubmit={handleRevealWithEstimate}
+          cards={cards}
+        />
       </>
     );
   }

--- a/src/containers/game-participants.tsx
+++ b/src/containers/game-participants.tsx
@@ -1,3 +1,4 @@
+import { WinStreakBadge } from '@/components/win-streak-badge';
 import { type RoundStatus } from '@/data/round/types';
 import { cn } from '@/lib/cn';
 import { useGame } from '@/providers/game';
@@ -44,6 +45,11 @@ export default function GameParticipants() {
             {participant.id === currentParticipant?.id && (
               <div className='absolute top-0 right-0 z-10'>
                 <EditUserProfileButton />
+              </div>
+            )}
+            {participant.winStreak && participant.winStreak > 0 && (
+              <div className='absolute top-0 left-0 z-10 -translate-x-1/2 -translate-y-1/2'>
+                <WinStreakBadge streak={participant.winStreak} />
               </div>
             )}
             <div

--- a/src/domain/participant/schemas.ts
+++ b/src/domain/participant/schemas.ts
@@ -10,6 +10,7 @@ export const BaseParticipantSchema = z.object({
   displayName: z.string(),
   role: z.enum(participantRoles),
   status: z.enum(participantStatuses),
+  winStreak: z.number().optional().default(0),
 });
 
 export const ParticipantSchema = DomainEntitySchema.merge(BaseParticipantSchema);

--- a/src/domain/round/schemas.ts
+++ b/src/domain/round/schemas.ts
@@ -7,6 +7,7 @@ const BaseRoundSchema = z.object({
   sessionId: z.string(),
   status: z.enum(roundStatuses),
   averageVote: z.number().nullable(),
+  originalEstimate: z.number().nullable(),
 });
 
 export const RoundSchema = DomainEntitySchema.merge(BaseRoundSchema);

--- a/src/hooks/round/use-reveal-round-with-streaks.ts
+++ b/src/hooks/round/use-reveal-round-with-streaks.ts
@@ -1,0 +1,19 @@
+import { revealRoundWithStreaks } from '@/services/round/reveal-round-with-streaks';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+/**
+ * Hook to reveal a round with original estimate and process win streaks
+ */
+export function useRevealRoundWithStreaks() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ roundId, originalEstimate }: { roundId: string; originalEstimate: number }) =>
+      revealRoundWithStreaks(roundId, originalEstimate),
+    onSuccess: () => {
+      // Invalidate relevant queries to refresh the UI
+      queryClient.invalidateQueries({ queryKey: ['round'] });
+      queryClient.invalidateQueries({ queryKey: ['participant'] });
+    },
+  });
+}

--- a/src/services/participant/__tests__/process-win-streaks.test.ts
+++ b/src/services/participant/__tests__/process-win-streaks.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import { processWinStreaks } from '../process-win-streaks';
+
+// Mock the dependencies
+vi.mock('@/data/vote/search-votes');
+vi.mock('@/data/participant/search-participants');
+vi.mock('@/data/participant/get-participant');
+vi.mock('../update-participant-streak');
+
+import { getParticipant } from '@/data/participant/get-participant';
+import { searchParticipants } from '@/data/participant/search-participants';
+import { searchVotes } from '@/data/vote/search-votes';
+import { updateParticipantStreak } from '../update-participant-streak';
+
+const mockSearchVotes = vi.mocked(searchVotes);
+const mockSearchParticipants = vi.mocked(searchParticipants);
+const mockGetParticipant = vi.mocked(getParticipant);
+const mockUpdateParticipantStreak = vi.mocked(updateParticipantStreak);
+
+describe('processWinStreaks', () => {
+  const roundId = 'round-123';
+  const originalEstimate = 5;
+
+  it('should increment streak for participants with correct votes', async () => {
+    // Arrange
+    const votes = [
+      { participantId: 'participant-1', value: 5, roundId },
+      { participantId: 'participant-2', value: 3, roundId },
+    ];
+    const participants = [
+      { id: 'participant-1', status: 'active', role: 'player' },
+      { id: 'participant-2', status: 'active', role: 'player' },
+    ];
+
+    mockSearchVotes.mockResolvedValue(votes as any);
+    mockSearchParticipants.mockResolvedValue(participants as any);
+    mockGetParticipant
+      .mockResolvedValueOnce({ winStreak: 2 } as any)
+      .mockResolvedValueOnce({ winStreak: 1 } as any);
+
+    // Act
+    await processWinStreaks(roundId, originalEstimate);
+
+    // Assert
+    expect(mockUpdateParticipantStreak).toHaveBeenCalledWith('participant-1', 3); // Increment from 2 to 3
+    expect(mockUpdateParticipantStreak).toHaveBeenCalledWith('participant-2', 0); // Reset to 0
+  });
+
+  it('should reset streak for participants with incorrect votes', async () => {
+    // Arrange
+    const votes = [
+      { participantId: 'participant-1', value: 3, roundId },
+    ];
+    const participants = [
+      { id: 'participant-1', status: 'active', role: 'player' },
+    ];
+
+    mockSearchVotes.mockResolvedValue(votes as any);
+    mockSearchParticipants.mockResolvedValue(participants as any);
+    mockGetParticipant.mockResolvedValue({ winStreak: 5 } as any);
+
+    // Act
+    await processWinStreaks(roundId, originalEstimate);
+
+    // Assert
+    expect(mockUpdateParticipantStreak).toHaveBeenCalledWith('participant-1', 0);
+  });
+
+  it('should handle participants with no current streak', async () => {
+    // Arrange
+    const votes = [
+      { participantId: 'participant-1', value: 5, roundId },
+    ];
+    const participants = [
+      { id: 'participant-1', status: 'active', role: 'player' },
+    ];
+
+    mockSearchVotes.mockResolvedValue(votes as any);
+    mockSearchParticipants.mockResolvedValue(participants as any);
+    mockGetParticipant.mockResolvedValue({ winStreak: undefined } as any);
+
+    // Act
+    await processWinStreaks(roundId, originalEstimate);
+
+    // Assert
+    expect(mockUpdateParticipantStreak).toHaveBeenCalledWith('participant-1', 1); // 0 + 1
+  });
+});

--- a/src/services/participant/update-participant-streak.ts
+++ b/src/services/participant/update-participant-streak.ts
@@ -1,0 +1,12 @@
+import { updateParticipant } from '@/data/participant/update-participant';
+
+/**
+ * Updates a participant's win streak
+ * @param participantId - The ID of the participant
+ * @param newStreak - The new streak value
+ */
+export async function updateParticipantStreak(participantId: string, newStreak: number) {
+  await updateParticipant(participantId, {
+    winStreak: newStreak,
+  });
+}

--- a/src/services/round/reveal-round-with-streaks.ts
+++ b/src/services/round/reveal-round-with-streaks.ts
@@ -1,0 +1,53 @@
+import { searchParticipants } from '@/data/participant/search-participants';
+import { updateRound } from '@/data/round/update-round';
+import { searchVotes } from '@/data/vote/search-votes';
+import { calculateAverage } from '@/lib/math';
+import { processWinStreaks } from '../participant/process-win-streaks';
+
+/**
+ * Reveals a round with the original estimate and processes win streaks
+ * @param roundId - The ID of the round to reveal
+ * @param originalEstimate - The original estimate set by the game owner
+ */
+export async function revealRoundWithStreaks(roundId: string, originalEstimate: number) {
+  const votes = await searchVotes({
+    filter: {
+      roundId,
+      value: {
+        op: '>=',
+        value: 0,
+      },
+    },
+  });
+
+  const participants = await searchParticipants({
+    filter: {
+      id: {
+        op: 'in',
+        value: votes.map((vote) => vote.participantId),
+      },
+      status: 'active',
+      role: {
+        op: 'in',
+        value: ['admin', 'owner', 'player'],
+      },
+    },
+  });
+
+  const validVotes = votes.filter((vote) =>
+    participants.some((participant) => participant.id === vote.participantId),
+  );
+
+  const voteValues = validVotes.map((vote) => vote.value);
+  const averageVote = calculateAverage(voteValues);
+
+  // Update round with average vote, status, and original estimate
+  await updateRound(roundId, {
+    averageVote,
+    status: 'revealed',
+    originalEstimate,
+  });
+
+  // Process win streaks for all participants
+  await processWinStreaks(roundId, originalEstimate);
+}


### PR DESCRIPTION
Implements the win streak feature requested in issue #246.

## Changes
- Add winStreak field to participant schema
- Add originalEstimate field to round schema
- Create WinStreakBadge component with fire icon 🔥
- Create OriginalEstimateDialog for game owner input
- Implement processWinStreaks service for streak logic
- Add revealRoundWithStreaks service and hook
- Update GameParticipants to display win streak badges
- Update GameActions to use original estimate dialog
- Add unit tests for new components and services

## How it Works
1. Game owner clicks "Reveal Vote" and gets prompted to enter the original estimate
2. Participants who voted for the original estimate get their win streak incremented (+1)
3. Participants who voted differently get their streak reset to 0
4. Win streaks display as fire badges (🔥) with the streak count on participant cards

Closes #246

Generated with [Claude Code](https://claude.ai/code)