### PR TITLE
chore: set position for Sonner toaster component

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -8,6 +8,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme}
       className='toaster group'
+      position='top-center'
       style={
         {
           '--normal-bg': 'var(--popover)',


### PR DESCRIPTION
This pull request makes a small UI adjustment to the `Toaster` component. The toast notifications will now appear at the top-center of the screen instead of the default position. 

- Set the `position` prop of the `Sonner` component in `sonner.tsx` to `'top-center'` so that toast notifications are displayed at the top-center of the viewport.