### PR TITLE
feat(session): add export votes as xlsx for admin and owner

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.11",
     "tw-animate-css": "^1.3.3",
+    "xlsx": "^0.18.5",
     "zod": "^3.25.67"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       tw-animate-css:
         specifier: ^1.3.3
         version: 1.3.3
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zod:
         specifier: ^3.25.67
         version: 3.25.67
@@ -2129,6 +2132,10 @@ packages:
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
@@ -2265,6 +2272,10 @@ packages:
   caniuse-lite@1.0.30001723:
     resolution: {integrity: sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
@@ -2338,6 +2349,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2485,6 +2500,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2817,6 +2837,10 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   framer-motion@12.23.12:
     resolution: {integrity: sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==}
@@ -3988,6 +4012,10 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -4332,9 +4360,17 @@ packages:
     resolution: {integrity: sha512-1lOb3qdzw6OFmOzoY0nauhLG72TpWtb5qgYPiSh/62rjc1XidBSDio2qw0pwHh17VINF217ebIkZJdFLZFn9SA==}
     engines: {node: '>=18'}
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
@@ -4346,6 +4382,11 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -6442,6 +6483,8 @@ snapshots:
 
   add-stream@1.0.0: {}
 
+  adler-32@1.3.1: {}
+
   agent-base@7.1.3: {}
 
   ajv@6.12.6:
@@ -6596,6 +6639,11 @@ snapshots:
 
   caniuse-lite@1.0.30001723: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
@@ -6693,6 +6741,8 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
+
+  codepage@1.15.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -6850,6 +6900,8 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.8.3
+
+  crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7232,6 +7284,8 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.3.3: {}
+
+  frac@1.1.2: {}
 
   framer-motion@12.23.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -8301,6 +8355,10 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stackback@0.0.2: {}
 
   std-env@3.9.0: {}
@@ -8622,7 +8680,11 @@ snapshots:
     dependencies:
       execa: 8.0.1
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wordwrap@1.0.0: {}
 
@@ -8637,6 +8699,16 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   y18n@5.0.8: {}
 

--- a/src/containers/game-settings-modal.tsx
+++ b/src/containers/game-settings-modal.tsx
@@ -38,7 +38,7 @@ const menus: {
   icon: React.ComponentType;
   role: ('player' | 'admin' | 'owner' | 'spectator')[];
 }[] = [
-  { name: 'General', icon: Settings2, role: ['owner'] },
+  { name: 'General', icon: Settings2, role: ['owner', 'admin'] },
   // { name: 'Account', icon: Settings2, role: ['player', 'owner'] },
   { name: 'Players', icon: Users2, role: ['owner'] },
 ];

--- a/src/containers/game-settings/general-settings.tsx
+++ b/src/containers/game-settings/general-settings.tsx
@@ -1,4 +1,5 @@
 import { Separator } from '@/components/ui/separator';
+import SessionExportButton from '../session-export-button';
 import SessionInformationContainer from '../session-information-container';
 import SessionTerminationButton from '../session-termination-button';
 
@@ -6,6 +7,11 @@ export default function GeneralSettings() {
   return (
     <div className='relative mx-auto flex w-full max-w-5xl flex-col gap-4'>
       <SessionInformationContainer />
+      <Separator />
+      <section className='flex flex-col gap-4'>
+        <p className='font-semibold'>Export</p>
+        <SessionExportButton />
+      </section>
       <Separator />
       <section className='flex flex-col gap-4'>
         <p className='font-semibold'>Danger Zone</p>

--- a/src/containers/session-export-button.tsx
+++ b/src/containers/session-export-button.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@/components/ui/button';
+import { useExportSessionVotes } from '@/hooks/session/use-export-session-votes';
+import { useSession } from '@/providers/session';
+import { Download } from 'lucide-react';
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+
+export default function SessionExportButton() {
+  const { id } = useSession();
+  const exportMutation = useExportSessionVotes();
+
+  const handleExport = useCallback(() => {
+    exportMutation.mutate(id, {
+      onSuccess: () => toast.success('Votes exported successfully'),
+      onError: (error) => toast.error(error.message),
+    });
+  }, [id, exportMutation]);
+
+  return (
+    <Button
+      variant='outline'
+      className='w-full md:w-fit'
+      onClick={handleExport}
+      disabled={exportMutation.isPending}
+    >
+      <Download />
+      <span>{exportMutation.isPending ? 'Exporting...' : 'Download votes (.xlsx)'}</span>
+    </Button>
+  );
+}

--- a/src/hooks/session/use-export-session-votes.ts
+++ b/src/hooks/session/use-export-session-votes.ts
@@ -1,0 +1,8 @@
+import { exportSessionVotes } from '@/services/session/export-session-votes';
+import { useMutation } from '@tanstack/react-query';
+
+export function useExportSessionVotes() {
+  return useMutation({
+    mutationFn: exportSessionVotes,
+  });
+}

--- a/src/lib/xlsx/__tests__/build-votes-workbook.test.ts
+++ b/src/lib/xlsx/__tests__/build-votes-workbook.test.ts
@@ -1,0 +1,143 @@
+import * as XLSX from 'xlsx';
+import { describe, expect, it } from 'vitest';
+
+import { type Participant } from '@/domain/participant/types';
+import { type Round } from '@/domain/round/types';
+import { type Vote } from '@/domain/vote/types';
+import { buildVotesWorkbook, type RoundWithVotes } from '../build-votes-workbook';
+
+const makeParticipant = (overrides: Partial<Participant> = {}): Participant => ({
+  id: 'p1',
+  sessionId: 'session1',
+  uid: 'uid1',
+  displayName: 'Alice',
+  role: 'player',
+  status: 'active',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+const makeRound = (overrides: Partial<Round> = {}): Round => ({
+  id: 'r1',
+  sessionId: 'session1',
+  status: 'finished',
+  averageVote: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+const makeVote = (overrides: Partial<Vote> = {}): Vote => ({
+  id: 'v1',
+  roundId: 'r1',
+  participantId: 'p1',
+  value: 5,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+function getSheetData(wb: XLSX.WorkBook, sheetName: string): unknown[][] {
+  const sheet = wb.Sheets[sheetName];
+  return XLSX.utils.sheet_to_json(sheet, { header: 1 }) as unknown[][];
+}
+
+describe('buildVotesWorkbook', () => {
+  it('returns workbook with one sheet named after the session', () => {
+    const wb = buildVotesWorkbook('My Session', [], []);
+    expect(wb.SheetNames).toHaveLength(1);
+    expect(wb.SheetNames[0]).toBe('My Session');
+  });
+
+  it('truncates sheet name to 31 characters', () => {
+    const longName = 'A'.repeat(40);
+    const wb = buildVotesWorkbook(longName, [], []);
+    expect(wb.SheetNames[0]).toHaveLength(31);
+  });
+
+  it('returns header-only sheet when no rounds provided', () => {
+    const participants = [makeParticipant({ displayName: 'Alice' })];
+    const wb = buildVotesWorkbook('Session', participants, []);
+    const data = getSheetData(wb, 'Session');
+    expect(data).toHaveLength(1);
+    expect(data[0]).toEqual(['Round', 'Alice', 'Average']);
+  });
+
+  it('fills vote values for each participant per round', () => {
+    const alice = makeParticipant({ id: 'p1', displayName: 'Alice' });
+    const bob = makeParticipant({ id: 'p2', displayName: 'Bob', uid: 'uid2' });
+    const participants = [alice, bob];
+
+    const round = makeRound({ id: 'r1', averageVote: 6 });
+    const votes: Vote[] = [
+      makeVote({ id: 'v1', roundId: 'r1', participantId: 'p1', value: 5 }),
+      makeVote({ id: 'v2', roundId: 'r1', participantId: 'p2', value: 8 }),
+    ];
+    const roundsWithVotes: RoundWithVotes[] = [{ round, votes }];
+
+    const wb = buildVotesWorkbook('Session', participants, roundsWithVotes);
+    const data = getSheetData(wb, 'Session');
+
+    expect(data[0]).toEqual(['Round', 'Alice', 'Bob', 'Average']);
+    expect(data[1]).toEqual([1, 5, 8, 6]);
+  });
+
+  it('uses empty string for missing votes', () => {
+    const alice = makeParticipant({ id: 'p1', displayName: 'Alice' });
+    const bob = makeParticipant({ id: 'p2', displayName: 'Bob', uid: 'uid2' });
+    const participants = [alice, bob];
+
+    const round = makeRound({ id: 'r1', averageVote: 5 });
+    // Only Alice voted
+    const votes: Vote[] = [makeVote({ id: 'v1', roundId: 'r1', participantId: 'p1', value: 5 })];
+    const roundsWithVotes: RoundWithVotes[] = [{ round, votes }];
+
+    const wb = buildVotesWorkbook('Session', participants, roundsWithVotes);
+    const data = getSheetData(wb, 'Session');
+
+    expect(data[1]).toEqual([1, 5, '', 5]);
+  });
+
+  it('excludes spectators from columns', () => {
+    const alice = makeParticipant({ id: 'p1', displayName: 'Alice', role: 'player' });
+    const spectator = makeParticipant({ id: 'p2', displayName: 'Observer', role: 'spectator', uid: 'uid2' });
+    const participants = [alice, spectator];
+
+    const wb = buildVotesWorkbook('Session', participants, []);
+    const data = getSheetData(wb, 'Session');
+
+    expect(data[0]).toEqual(['Round', 'Alice', 'Average']);
+    expect(data[0]).not.toContain('Observer');
+  });
+
+  it('numbers rounds sequentially starting at 1', () => {
+    const participants = [makeParticipant()];
+    const roundsWithVotes: RoundWithVotes[] = [
+      { round: makeRound({ id: 'r1' }), votes: [] },
+      { round: makeRound({ id: 'r2' }), votes: [] },
+      { round: makeRound({ id: 'r3' }), votes: [] },
+    ];
+
+    const wb = buildVotesWorkbook('Session', participants, roundsWithVotes);
+    const data = getSheetData(wb, 'Session');
+
+    expect(data[1][0]).toBe(1);
+    expect(data[2][0]).toBe(2);
+    expect(data[3][0]).toBe(3);
+  });
+
+  it('uses empty string for null averageVote', () => {
+    const participants = [makeParticipant()];
+    const roundsWithVotes: RoundWithVotes[] = [
+      { round: makeRound({ id: 'r1', averageVote: null }), votes: [] },
+    ];
+
+    const wb = buildVotesWorkbook('Session', participants, roundsWithVotes);
+    const data = getSheetData(wb, 'Session');
+
+    // Average column is last
+    const averageCell = data[1][data[1].length - 1];
+    expect(averageCell).toBe('');
+  });
+});

--- a/src/lib/xlsx/build-votes-workbook.ts
+++ b/src/lib/xlsx/build-votes-workbook.ts
@@ -1,0 +1,55 @@
+import * as XLSX from 'xlsx';
+
+import { type Participant } from '@/domain/participant/types';
+import { type Round } from '@/domain/round/types';
+import { type Vote } from '@/domain/vote/types';
+
+export interface RoundWithVotes {
+  round: Round;
+  votes: Vote[];
+}
+
+/**
+ * Builds an XLSX workbook from session voting data.
+ *
+ * The workbook contains a single sheet with one row per round.
+ * Columns: Round | <participant names...> | Average
+ *
+ * @param sessionName - The session name used as the sheet name (truncated to 31 chars)
+ * @param participants - All participants (including those who left/were removed)
+ * @param roundsWithVotes - Rounds with their associated votes, sorted by createdAt asc
+ * @returns An XLSX workbook ready to be written to file
+ */
+export function buildVotesWorkbook(
+  sessionName: string,
+  participants: Participant[],
+  roundsWithVotes: RoundWithVotes[],
+): XLSX.WorkBook {
+  const nonSpectators = participants.filter((p) => p.role !== 'spectator');
+
+  const headers = ['Round', ...nonSpectators.map((p) => p.displayName), 'Average'];
+
+  const rows: (string | number)[][] = roundsWithVotes.map(({ round, votes }, index) => {
+    const votesByParticipantId = votes.reduce(
+      (acc, vote) => {
+        acc[vote.participantId] = vote.value;
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+
+    const voteValues = nonSpectators.map((p) => votesByParticipantId[p.id] ?? '');
+
+    return [index + 1, ...voteValues, round.averageVote ?? ''];
+  });
+
+  const sheetData = [headers, ...rows];
+  const sheet = XLSX.utils.aoa_to_sheet(sheetData);
+
+  const wb = XLSX.utils.book_new();
+  // Excel sheet names are limited to 31 characters
+  const sheetName = sessionName.slice(0, 31);
+  XLSX.utils.book_append_sheet(wb, sheet, sheetName);
+
+  return wb;
+}

--- a/src/lib/xlsx/index.ts
+++ b/src/lib/xlsx/index.ts
@@ -1,0 +1,1 @@
+export * from './build-votes-workbook';

--- a/src/services/session/export-session-votes.ts
+++ b/src/services/session/export-session-votes.ts
@@ -1,0 +1,47 @@
+import * as XLSX from 'xlsx';
+
+import { searchParticipants } from '@/data/participant/search-participants';
+import { searchRounds } from '@/data/round/search-rounds';
+import { getSession } from '@/data/session/get-session';
+import { searchVotes } from '@/data/vote/search-votes';
+import { buildVotesWorkbook } from '@/lib/xlsx/build-votes-workbook';
+import { checkIfUserCanManageSession } from './access-control';
+
+/**
+ * Exports all voting data for a session as an XLSX file download.
+ *
+ * Fetches all finished and revealed rounds with their votes, then triggers
+ * a browser file download. Only session owners and admins can export.
+ *
+ * @param sessionId - The ID of the session to export
+ * @throws If the user is not authenticated or does not have manage permissions
+ */
+export async function exportSessionVotes(sessionId: string): Promise<void> {
+  await checkIfUserCanManageSession(sessionId);
+
+  const session = await getSession(sessionId);
+  if (!session) throw new Error('Session not found');
+
+  const [participants, rounds] = await Promise.all([
+    searchParticipants({ filter: { sessionId }, order: { field: 'createdAt', direction: 'asc' } }),
+    searchRounds({
+      filter: {
+        sessionId,
+        status: { op: 'in', value: ['finished', 'revealed'] },
+      },
+      order: { field: 'createdAt', direction: 'asc' },
+    }),
+  ]);
+
+  const roundsWithVotes = await Promise.all(
+    rounds.map(async (round) => ({
+      round,
+      votes: await searchVotes({
+        filter: { roundId: round.id },
+      }),
+    })),
+  );
+
+  const wb = buildVotesWorkbook(session.name, participants, roundsWithVotes);
+  XLSX.writeFile(wb, `${session.name}-votes.xlsx`);
+}


### PR DESCRIPTION
This pull request adds the ability to export session votes as an Excel (.xlsx) file from the game settings. The feature is accessible to both owners and admins and includes backend logic, UI components, and supporting tests. The `xlsx` library and its dependencies are added to the project to enable Excel file generation.

**New session votes export feature:**

* Added a new "Export" section and `SessionExportButton` to the `GeneralSettings` modal, allowing owners and admins to export session votes as an `.xlsx` file. [[1]](diffhunk://#diff-0c9c33631832c1c202dca4916b8412966111697b8c191888db045142c8ba6e15L41-R41) [[2]](diffhunk://#diff-8d8eb48911512836996fb124950aad0b9ec886e297eef34124ecfae7d3d43428R2) [[3]](diffhunk://#diff-8d8eb48911512836996fb124950aad0b9ec886e297eef34124ecfae7d3d43428R11-R15) [[4]](diffhunk://#diff-807ddf228c6988a687cde770bf2949be1b3820a5aeb99275d13e32eb2cd35ea9R1-R30)
* Implemented the `useExportSessionVotes` React hook and integrated it with the export button for session vote export functionality.
* Added the `buildVotesWorkbook` utility to generate an Excel workbook from session voting data, along with comprehensive unit tests to verify correct export formatting and edge cases. [[1]](diffhunk://#diff-652fc3fe4bf43fa1146db901b51b4af68e1a25933c255e09968a4da767a549a8R1-R55) [[2]](diffhunk://#diff-0673b83683e74a75ff3c1d68487bceb4c20ae178bc6a2bd6e971f42bb1eb85baR1-R143)
* Exported the `buildVotesWorkbook` utility from the xlsx library index for reuse.

**Dependency updates:**

* Added the `xlsx` library and its required dependencies (`adler-32`, `cfb`, `codepage`, `crc-32`, `ssf`, `frac`, `wmf`, `word`) to `package.json` and `pnpm-lock.yaml` to support Excel file creation. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R60) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR119-R121) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2135-R2138) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2275-R2278) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2353-R2356) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2504-R2508) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2841-R2844) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4015-R4018) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4363-R4374) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4386-R4390) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6486-R6487) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6642-R6646) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6745-R6746) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6904-R6905) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7288-R7289) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8358-R8361) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8683-R8688) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8703-R8712)